### PR TITLE
Fixed building on Haiku when freetype is only available in x86

### DIFF
--- a/build/BuildSettings
+++ b/build/BuildSettings
@@ -28,7 +28,6 @@ if $(OSPLAT) = X86 {
 		}
 		NETWORK_LIBS += network ;
 		PLATFORM = haiku ;
-		COMMON_FOLDER = /boot/common ;
 		
 		local freeTypeDir ;
 		


### PR DESCRIPTION
When creating a recipe for HaikuPorts, you declare what headers/commands/whatever you require in order to build the package, and you get only what you declare (and some others you don't declare). When you require the development headers for freetype, you get them in headers/x86/freetype2, if you are building on gcc4, and not in headers/freetype2. In BuildSettings, headers/freetype2 was added as an include dir, no matter the architecture we are building on. Now, it checks the gcc version and adds the corresponding directory.
